### PR TITLE
Improve error handling for item read with rasterio and prepare to release 0.9.0-12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,14 @@
 Changes
 =======
 
+
+Version 0.9.0-12 (2021-06-15)
+-----------------------------
+
+- Improve ReadTheDocs documentation related with API (`#81 <https://github.com/brazil-data-cube/stac.py/issues/81>`_).
+- Improve error message while downloading or accessing any asset (`#68 <https://github.com/brazil-data-cube/stac.py/issues/68>`_).
+
+
 Version 0.9.0-11 (2021-04-22)
 -----------------------------
 

--- a/stac/stac.py
+++ b/stac/stac.py
@@ -85,7 +85,7 @@ class STAC:
         return self._collections
 
 
-    def collection(self, collection_id):
+    def collection(self, collection_id) -> Collection:
         """Return the given collection.
 
         :param collection_id: A str for a given collection_id.

--- a/stac/version.py
+++ b/stac/version.py
@@ -13,4 +13,4 @@ and parsed by ``setup.py``.
 """
 
 
-__version__ = '0.9.0-11'
+__version__ = '0.9.0-12'


### PR DESCRIPTION
I've created the function ``Utils.safe_request`` to keep as default error handlers for any HTTP Request like rasterio open remote files.