### PR TITLE
Add arguments to pass to request

### DIFF
--- a/stac/stac.py
+++ b/stac/stac.py
@@ -25,7 +25,7 @@ class STAC:
     :type url: str
     """
 
-    def __init__(self, url, validate=False, access_token=None):
+    def __init__(self, url, validate=False, access_token=None, **request_kwargs):
         """Create a STAC client attached to the given host address (an URL).
 
         :param url: URL for the Root STAC Catalog.
@@ -40,11 +40,12 @@ class STAC:
         self._catalog = dict()
         self._validate = validate
         self._access_token = f'?access_token={access_token}' if access_token else ''
+        self._request_kwargs = request_kwargs
 
     @property
     def conformance(self): # pragma: no cover
         """Return the list of conformance classes that the server conforms to."""
-        return Utils._get('{}/conformance'.format(self._url))
+        return Utils._get('{}/conformance'.format(self._url),  **self._request_kwargs)
 
     @property
     def catalog(self):
@@ -55,7 +56,7 @@ class STAC:
         """
         if not self._catalog:
             url = f'{self._url}{self._access_token}'
-            response = Utils._get(url)
+            response = Utils._get(url, **self._request_kwargs)
 
             self._catalog = Catalog(response, self._validate)
 
@@ -69,7 +70,7 @@ class STAC:
                     self._collections[collection_name[:collection_name.index('?')]] = None
                 else:
                     self._collections[i.href.split('/')[-1]] = None
-        return list(self._collections.keys())
+        return list(self._collections.items())
 
 
     @property
@@ -80,7 +81,7 @@ class STAC:
         :rype: dict
         """
         url = '/'.join(self._url.split('/')[:-1]) if self._url.endswith('/stac') else self._url
-        data = Utils._get(f'{url.rstrip("/")}/collections{self._access_token}')
+        data = Utils._get(f'{url.rstrip("/")}/collections{self._access_token}', **self._request_kwargs)
         self._collections = {collection['id']: Collection(collection, self._validate) for collection in data['collections']}
 
         return self._collections
@@ -100,7 +101,7 @@ class STAC:
             return self._collections[collection_id]
         try:
             url = '/'.join(self._url.split('/')[:-1]) if self._url.endswith('/stac') else self._url
-            data = Utils._get(f'{url.rstrip("/")}/collections/{collection_id}{self._access_token}')
+            data = Utils._get(f'{url.rstrip("/")}/collections/{collection_id}{self._access_token}',  **self._request_kwargs)
             self._collections[collection_id] = Collection(data, self._validate)
         except HTTPError as e:
             raise KeyError(f'Could not retrieve information for collection: {collection_id}')
@@ -124,7 +125,7 @@ class STAC:
         if filter is not None and 'bbox' in filter:
             filter['bbox'] = Utils.build_bbox_as_str(filter['bbox'])
 
-        data = Utils._get(url, params=filter)
+        data = Utils._get(url, params=filter,  **self._request_kwargs)
         return ItemCollection(data, self._validate)
 
     @property

--- a/stac/stac.py
+++ b/stac/stac.py
@@ -70,7 +70,7 @@ class STAC:
                     self._collections[collection_name[:collection_name.index('?')]] = None
                 else:
                     self._collections[i.href.split('/')[-1]] = None
-        return list(self._collections.items())
+        return list(self._collections.keys())
 
 
     @property

--- a/stac/utils.py
+++ b/stac/utils.py
@@ -23,7 +23,7 @@ class Utils:
     """Utils STAC object."""
 
     @staticmethod
-    def _get(url, params=None):
+    def _get(url, params=None, **request_kwargs):
         """Query the STAC service using HTTP GET verb and return the result as a JSON document.
 
         :param url: The URL to query must be a valid STAC endpoint.
@@ -47,13 +47,13 @@ class Utils:
                 if 'bbox' in params and isinstance(params['bbox'], str):
                     params['bbox'] = [float(coord) for coord in params['bbox'].split(',')]
 
-                response = requests.post(url, json=params)
+                response = requests.post(url, json=params, **request_kwargs)
             else:
                 if 'collections' in params and type(params['collections']) in (tuple, list):
                     params['collections'] = ','.join(params['collections'])
-                response = requests.get(url, params=params)
+                response = requests.get(url, params=params,  **request_kwargs)
         else:
-            response = requests.get(url)
+            response = requests.get(url,  **request_kwargs)
 
         response.raise_for_status()
 


### PR DESCRIPTION
Added a **kwarg argument to the stac class to pass down request parameters, main purpose was to pass `verify=False` down to the GET requests when instantiating so that uncertified SSL links can be utilised.
I believe this to be generally useful to others as it is allowing more control over the request get call.