### PR TITLE
Duplicate 0.9.0 as 1.0.0 jsonschema

### DIFF
--- a/stac/jsonschemas/1.0.0/basics.json
+++ b/stac/jsonschemas/1.0.0/basics.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "basics.json#",
+  "title": "Basic Descriptive Fields",
+  "type": "object",
+  "properties": {
+    "title": {
+      "title": "Item Title",
+      "description": "A human-readable title describing the Item.",
+      "type": "string"
+    },
+    "description": {
+      "title": "Item Description",
+      "description": "Detailed multi-line description to fully explain the Item.",
+      "type": "string"
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/catalog.json
+++ b/stac/jsonschemas/1.0.0/catalog.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "catalog.json#",
+  "title": "STAC Catalog Specification",
+  "description": "This object represents Catalogs in a SpatioTemporal Asset Catalog.",
+  "allOf": [
+    {
+      "$ref": "#/definitions/catalog"
+    }
+  ],
+  "definitions": {
+    "catalog": {
+      "title": "Catalog",
+      "type": "object",
+      "required": [
+        "stac_version",
+        "id",
+        "description",
+        "links"
+      ],
+      "properties": {
+        "stac_version": {
+          "title": "STAC version",
+          "type": "string",
+          "const": "0.9.0"
+        },
+        "stac_extensions": {
+          "title": "STAC extensions",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "title": "Identifier",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "links": {
+          "title": "Links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/link"
+          }
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "required": [
+        "rel",
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "title": "Link reference",
+          "type": "string"
+        },
+        "rel": {
+          "title": "Link relation type",
+          "type": "string"
+        },
+        "type": {
+          "title": "Link type",
+          "type": "string"
+        },
+        "title": {
+          "title": "Link title",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/collection.json
+++ b/stac/jsonschemas/1.0.0/collection.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "collection.json#",
+  "title": "STAC Collection Specification",
+  "description": "This object represents Collections in a SpatioTemporal Asset Catalog.",
+  "allOf": [
+    {
+      "$ref": "catalog.json"
+    },
+    {
+      "$ref": "#/definitions/collection"
+    }
+  ],
+  "definitions": {
+    "collection": {
+      "title": "STAC Collection",
+      "description": "These are the fields specific to a STAC Collection. All other fields are inherited from STAC Catalog.",
+      "type": "object",
+      "required": [
+        "license",
+        "extent"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "title": "STAC extensions",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Reference to a JSON Schema",
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "title": "Reference to a core extension",
+                "type": "string",
+                "enum": [
+                  "asset",
+                  "commons",
+                  "checksum",
+                  "datacube",
+                  "scientific",
+                  "version"
+                ]
+              }
+            ]
+          }
+        },
+        "keywords": {
+          "title": "Keywords",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "license": {
+          "title": "Collection License Name",
+          "type": "string",
+          "pattern": "^[\\w\\-\\.\\+]+$"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "name": {
+                "title": "Organization name",
+                "type": "string"
+              },
+              "description": {
+                "title": "Organization description",
+                "type": "string"
+              },
+              "roles": {
+                "title": "Organization roles",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "producer",
+                    "licensor",
+                    "processor",
+                    "host"
+                  ]
+                }
+              },
+              "url": {
+                "title": "Organization homepage",
+                "type": "string",
+                "format": "url"
+              }
+            }
+          }
+        },
+        "extent": {
+          "title": "Extents",
+          "type": "object",
+          "required": [
+            "spatial",
+            "temporal"
+          ],
+          "properties": {
+            "spatial": {
+              "title": "Spatial extent object",
+              "type": "object",
+              "required": [
+                "bbox"
+              ],
+              "properties": {
+                "bbox": {
+                  "title": "Spatial extents",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "title": "Spatial extent",
+                    "type": "array",
+                    "minItems": 4,
+                    "maxItems": 6,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            },
+            "temporal": {
+              "title": "Temporal extent object",
+              "type": "object",
+              "required": [
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "title": "Temporal extents",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "title": "Temporal extent",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summaries": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "title": "Stats",
+                "type": "object",
+                "required": [
+                  "min",
+                  "max"
+                ],
+                "properties": {
+                  "min": {
+                    "title": "Minimum value",
+                    "type": ["number", "string"]
+                  },
+                  "max": {
+                    "title": "Maximum value",
+                    "type": ["number", "string"]
+                  }
+                }
+              },
+              {
+                "title": "Set of values",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Any data type could occur."
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/datetimerange.json
+++ b/stac/jsonschemas/1.0.0/datetimerange.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "datetimerange.json#",
+  "title": "Date and Time Range Fields",
+  "type": "object",
+  "properties": {
+    "start_datetime": {
+      "title": "Start Date and Time",
+      "description": "The searchable start date/time of the assets, in UTC (Formatted in RFC 3339) ",
+      "type": "string",
+      "format": "date-time"
+    },
+    "end_datetime": {
+      "title": "End Date and Time",
+      "description": "The searchable end date/time of the assets, in UTC (Formatted in RFC 3339) ",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "dependencies": {
+    "start_datetime": {
+      "required": [
+        "end_datetime"
+      ]
+    },
+    "end_datetime": {
+      "required": [
+        "start_datetime"
+      ]
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/instrument.json
+++ b/stac/jsonschemas/1.0.0/instrument.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "instrument.json#",
+  "title": "Instrument Fields",
+  "type": "object",
+  "properties": {
+    "platform": {
+      "title": "Platform",
+      "type": "string"
+    },
+    "instruments": {
+      "title": "Instruments",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "constellation": {
+      "title": "Constellation",
+      "type": "string"
+    },
+    "mission": {
+      "title": "Mission",
+      "type": "string"
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/item.json
+++ b/stac/jsonschemas/1.0.0/item.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "item.json#",
+  "title": "STAC Item",
+  "type": "object",
+  "description": "This object represents the metadata for an item in a SpatioTemporal Asset Catalog.",
+  "additionalProperties": true,
+  "allOf": [
+    {
+      "$ref": "#/definitions/core"
+    }
+  ],
+  "definitions": {
+    "common_metadata": {
+      "allOf": [
+        {
+          "$ref": "basics.json"
+        },
+        {
+          "$ref": "datetimerange.json"
+        },
+        {
+          "$ref": "instrument.json"
+        },
+        {
+          "$ref": "licensing.json"
+        },
+        {
+          "$ref": "metadata.json"
+        },
+        {
+          "$ref": "provider.json"
+        }
+      ]
+    },
+    "core": {
+      "allOf": [
+        {
+          "$ref": "https://geojson.org/schema/Feature.json"
+        },
+        {
+          "type": "object",
+          "required": [
+            "stac_version",
+            "id",
+            "links",
+            "assets",
+            "bbox",
+            "properties"
+          ],
+          "properties": {
+            "stac_version": {
+              "title": "STAC version",
+              "type": "string",
+              "const": "0.9.0"
+            },
+            "stac_extensions": {
+              "title": "STAC extensions",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "Reference to a JSON Schema",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  {
+                    "title": "Reference to a core extension",
+                    "type": "string",
+                    "enum": [
+                      "checksum",
+                      "commons",
+                      "datacube",
+                      "eo",
+                      "label",
+                      "pointcloud",
+                      "projection",
+                      "sar",
+                      "sat",
+                      "scientific",
+                      "version",
+                      "view"
+                    ]
+                  }
+                ]
+              }
+            },
+            "id": {
+              "title": "Provider ID",
+              "description": "Provider item ID",
+              "type": "string"
+            },
+            "bbox": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "number"
+              }
+            },
+            "links": {
+              "title": "Item links",
+              "description": "Links to item relations",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/link"
+              }
+            },
+            "assets": {
+              "title": "Asset links",
+              "description": "Links to assets",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/asset"
+              }
+            },
+            "properties": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "required": [
+                    "datetime"
+                  ],
+                  "properties": {
+                    "datetime": {
+                      "title": "Date and Time",
+                      "description": "The searchable date/time of the assets, in UTC (Formatted in RFC 3339) ",
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/definitions/common_metadata"
+                }
+              ]
+            },
+            "collection": {
+              "title": "Collection ID",
+              "description": "The ID of the STAC Collection this Item references to.",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "link": {
+      "type": "object",
+      "required": [
+        "rel",
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "title": "Link reference",
+          "type": "string"
+        },
+        "rel": {
+          "title": "Link relation type",
+          "type": "string"
+        },
+        "type": {
+          "title": "Link type",
+          "type": "string"
+        },
+        "title": {
+          "title": "Link title",
+          "type": "string"
+        }
+      }
+    },
+    "asset": {
+      "type": "object",
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "title": "Asset reference",
+          "type": "string"
+        },
+        "title": {
+          "title": "Asset title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Asset description",
+          "type": "string"
+        },
+        "type": {
+          "title": "Asset type",
+          "type": "string"
+        },
+        "roles": {
+          "title": "Asset roles",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/itemcollection.json
+++ b/stac/jsonschemas/1.0.0/itemcollection.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "itemcollection.json#",
+  "title": "STAC ItemCollection",
+  "type": "object",
+  "description": "This object represents the metadata for a set of items in a SpatioTemporal Asset Catalog.",
+  "additionalProperties": true,
+  "allOf": [
+    {
+      "$ref": "#/definitions/core"
+    }
+  ],
+  "definitions": {
+    "core": {
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "$ref": "https://geojson.org/schema/FeatureCollection.json"
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "features"
+          ],
+          "properties": {
+            "stac_version": {
+              "title": "STAC version",
+              "type": "string",
+              "const": "0.9.0"
+            },
+            "stac_extensions": {
+              "title": "STAC extensions",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "Reference to a JSON Schema",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  {
+                    "title": "Reference to a core extension",
+                    "type": "string",
+                    "enum": [
+                      "single-file-stac"
+                    ]
+                  }
+                ]
+              }
+            },
+            "type": {
+              "title": "Type",
+              "description": "Type of entity, always FeatureCollection",
+              "type": "string"
+            },
+            "features": {
+              "title": "ItemCollection features",
+              "description": "Items in this item collection",
+              "type": "array",
+              "items": {
+                "$ref": "item.json"
+              }
+            },
+            "links": {
+              "title": "Links",
+              "description": "Links to item collection relations",
+              "type": "array",
+              "items": {
+                "$ref": "item.json#/definitions/link"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/licensing.json
+++ b/stac/jsonschemas/1.0.0/licensing.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "licensing.json#",
+  "title": "Licensing Fields",
+  "type": "object",
+  "properties": {
+    "license": {
+      "type": "string",
+      "pattern": "^[\\w\\-\\.\\+]+$"
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/metadata.json
+++ b/stac/jsonschemas/1.0.0/metadata.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "metadata.json#",
+  "title": "Metadata Fields",
+  "type": "object",
+  "properties": {
+    "created": {
+      "title": "Metadata Creation",
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated": {
+      "title": "Metadata Last Update",
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/stac/jsonschemas/1.0.0/provider.json
+++ b/stac/jsonschemas/1.0.0/provider.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "provider.json#",
+  "title": "Provider Fields",
+  "type": "object",
+  "properties": {
+    "providers": {
+      "title": "Providers",
+      "type": "array",
+      "items": {
+        "properties": {
+          "name": {
+            "title": "Organization name",
+            "type": "string"
+          },
+          "description": {
+            "title": "Organization description",
+            "type": "string"
+          },
+          "roles": {
+            "title": "Organization roles",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "producer",
+                "licensor",
+                "processor",
+                "host"
+              ]
+            }
+          },
+          "url": {
+            "title": "Organization homepage",
+            "type": "string",
+            "format": "url"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Duplicated the JSON Schema for 0.9.0 for 1.0.0, the JSON schema selected is from the stac object returned. Since the current stac version is 1.0.0 and stac.py has not been updated to that, added a clone of 0.9.0 as 1.0.0 schema.
Resolves issue where directory jsonschema/1.0.0 not found where 1.0.0 is version of STAC object retrieved.