### PR TITLE
Add compatibility for faceted search STAC1.0.0-beta.3

### DIFF
--- a/stac/cli.py
+++ b/stac/cli.py
@@ -116,7 +116,7 @@ def search(url, collections, ids, intersects, limit, next, page, datetime, bbox,
     if ids is not None:
         filter['ids'] = ids
 
-    retval = service.search(filter=filter)
+    retval = service.search(**filter)
 
     print(json.dumps(retval, indent=2))
 

--- a/stac/stac.py
+++ b/stac/stac.py
@@ -110,11 +110,11 @@ class STAC:
         return self._collections[collection_id]
 
 
-    def search(self, filter=None):
+    def search(self, **query):
         """Retrieve Items matching a filter.
 
-        :param filter: (optional) A dictionary with valid STAC query parameters.
-        :type filter: dict
+        :param query: (optional) A dictionary with valid STAC query parameters from query kwarg.
+        :type query: dict
 
         :returns: A GeoJSON FeatureCollection.
         :rtype: dict
@@ -124,10 +124,10 @@ class STAC:
 
         url = f'{self._url}/search{self._access_token}'
 
-        if filter is not None and 'bbox' in filter:
-            filter['bbox'] = Utils.build_bbox_as_str(filter['bbox'])
+        if 'bbox' in query:
+            query['bbox'] = Utils.build_bbox_as_str(query['bbox'])
 
-        data = Utils._get(url, params=filter, **self._request_kwargs)
+        data = Utils._get(url, params=query, **self._request_kwargs)
         return ItemCollection(data, self._validate)
 
     @property

--- a/stac/utils.py
+++ b/stac/utils.py
@@ -39,7 +39,7 @@ class Utils:
         response = None
 
         if params is not None:
-            if 'intersects' in params or 'query' in params:
+            if 'intersects' in params or 'query' in params or 'filter' in params:
                 if 'collections' in params and isinstance(params['collections'], str):
                     params['collections'] = params['collections'].split(',')
                 if 'ids' in params and isinstance(params['ids'], str):

--- a/tests/stac_tests/test_stac.py
+++ b/tests/stac_tests/test_stac.py
@@ -306,10 +306,10 @@ class TestStac:
                               headers={'content-type':'application/json'})
 
             with pytest.raises(TypeError):
-                s.search(filter={"bbox": ""})
+                s.search(bbox="")
 
             with pytest.raises(TypeError):
-                s.search(filter={"bbox": -90})
+                s.search(bbox=-90)
 
     def test_stac_read_forbidden(self, stac_objects, requests_mock):
         for k in stac_objects:


### PR DESCRIPTION
Hello, I was wondering if you would be interested in adding faceted search to stac.py as per spec: [https://api.stacspec.org/v1.0.0-beta.3/item-search/#operation/getItemSearch](https://api.stacspec.org/v1.0.0-beta.3/item-search/#operation/getItemSearchl)

I have added compatibility in my own fork for faceted search to use for our STAC endpoint. Which required me to make a couple of changes I will try to justify in this PR:

- **search `filter` argument changed to `query **kwargs`**: As per spec, the faceted search is implemented by the 'filter' key where 'filter' is a dictionary of boolean followed by properties. I thought it to be confusing for 'filter' to be both the argument name for generic queries and the name of the facet query.
    - Reason to change to kwargs I thought would be more intuitive for search, ie:
    instead of `search(filter={'collections': ['collection_id']})`, a more intuitive method of approach for an end user would be `search(collections=['collection_id)`
- In `stac/utils.py` L42, added 'filter' to the params to check for a POST search. As necessary for a faceted search, described in the api spec.
- **Changes to `tests/stac_tests/test_stac.py, test_empty_bbox`**: I had to change how the search function was called, as follows in the changes described above, to pass all tests.