### PR TITLE
rstrip trailing '/' from URL

### DIFF
--- a/stac/stac.py
+++ b/stac/stac.py
@@ -35,7 +35,7 @@ class STAC:
         :param access_token: Authentication for the STAC API
         :type access_token: str
         """
-        self._url = url.rstrip('/') if url[-1] == '/' else url
+        self._url = url.rstrip('/')
         self._collections = dict()
         self._catalog = dict()
         self._validate = validate

--- a/stac/stac.py
+++ b/stac/stac.py
@@ -35,7 +35,7 @@ class STAC:
         :param access_token: Authentication for the STAC API
         :type access_token: str
         """
-        self._url = url
+        self._url = url.rstrip('/') if url[-1] == '/' else url
         self._collections = dict()
         self._catalog = dict()
         self._validate = validate


### PR DESCRIPTION
Hello, I thought that this small change would be nice to remove a trailing '/' for any URL entered by an end-user of the client.
Since you can't rely on the end-user initialising the client properly with a URL *not* ending in a '/'.