### PR TITLE
Binder notebook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,10 @@ Python Client Library for STAC
         :target: https://discord.com/channels/689541907621085198#
         :alt: Join us at Discord
 
+.. image:: https://mybinder.org/badge_logo.svg
+        :target: https://mybinder.org/v2/gh/cedadev/stac.py/usage-notebook?filepath=examples%2Fusage.ipynb
+        :alt: Binder interactive notebook
+
 About
 =====
 

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -1,0 +1,330 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Usage\n",
+    "\n",
+    "## Initialise Client\n",
+    "\n",
+    "Instantiate the STAC class with a valid STAC url endpoint.\n",
+    "\n",
+    "(Optional) Pass in any arguments needed to access the endpoint such as\n",
+    "headers and verification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from stac.stac import STAC\n",
+    "\n",
+    "url = 'https://stac-elasticsearch-master.130.246.131.9.nip.io/'\n",
+    "Client = STAC(url=url, verify=False)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Basic GET usages\n",
+    "\n",
+    "### GET Collections\n",
+    "\n",
+    "**/collections**\n",
+    "\n",
+    "Retrieve a list of collections available at from the STAC endpoint."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "collections = Client.get_collections()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### GET Collection\n",
+    "\n",
+    "**/collections/{collectionId}**\n",
+    "\n",
+    "Retreive a collection, given a collection ID, from the STAC endpoint."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "collection_id = Client.catalog[0]\n",
+    "collection = Client.get_collection(collection_id=collection_id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### GET Itemcollection\n",
+    "\n",
+    "**/collections/{collectionId}/items**\n",
+    "\n",
+    "Retrieve a list of items of a specific collection."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "items = Client.items(collection_id=collection_id)\n",
+    "# or get an item collection from a collection object:\n",
+    "items = collection.get_items()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### GET Item\n",
+    "\n",
+    "**/collections/{collectionId}/items/{itemId}**\n",
+    "\n",
+    "Retrieve an item object, from a specific collection, given an item ID."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "item_id = '2ef41eee0710db0a04c7089b3da3ee6b'\n",
+    "item = Client.items(collection_id=collection_id, item_id=item_id)\n",
+    "# or get an item from a collection object given an item ID\n",
+    "item = collection.get_items(item_id=item_id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### GET Assets\n",
+    "\n",
+    "Retrieve a list of assets of a given item."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "assets = item.assets"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Search\n",
+    "\n",
+    "Usages examples of how search using the python wrapper client.\n",
+    "(See Conformance classes `item-search` for capabilities)\n",
+    "\n",
+    "### Basic Usage:\n",
+    "\n",
+    "Search the STAC endpoint by filtering through these optional keys:\n",
+    "* collections: list of collection IDs\n",
+    "* ids: list of item IDs\n",
+    "* bbox: list of integers for bounding box\n",
+    "* datetime: string of open/closed ended dates or single date.\n",
+    "* limit: number of items to list in one page. *Default 10*."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "Client.search()\n",
+    "# returns every item available\n",
+    "\n",
+    "Client.search(\n",
+    "    collections=['Fj3reHsBhuk7QqVbt7P-'],\n",
+    "    ids=['2ef41eee0710db0a04c7089b3da3ee6b'],\n",
+    "    bbox=[-180, -90, 180, 90],\n",
+    "    datetime='2018-02-12T00:00:00Z/2018-03-18T12:31:12Z',\n",
+    "    limit=10\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Free Text Search\n",
+    "\n",
+    "Free text search is provided by the client, using a positional argument as the first\n",
+    "or by the `q` parameter.\n",
+    "Free text search supports case-insensitive and partial search.\n",
+    "\n",
+    "Free text search is provided by this STAC extension:\n",
+    "\n",
+    "- https://api.stacspec.org/v1.0.0-beta.2/item-search#free-text-search"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# All these queries end up with the same search result:\n",
+    "\n",
+    "result = Client.search(q=\"AerChemMIP\")\n",
+    "result = Client.search(q=\"aerchemmip\")\n",
+    "result = Client.search(q=\"AerChem*\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Facet Search\n",
+    "Filter the search result based on facets of an item. The facet request body\n",
+    "should use a dictionary with valid facets found with queryables, labeled under\n",
+    "the filter argument.\n",
+    "\n",
+    "Facet search is provided by this STAC extension:\n",
+    "\n",
+    "- https://api.stacspec.org/v1.0.0-beta.3/item-search/#operation/postItemSearch"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "result = Client.search(\n",
+    "    filter={\n",
+    "        \"institution_id\": [\"CNRM-CERF\"]\n",
+    "    }\n",
+    ")\n",
+    "# The filter is the label for facet search where it consists of a dictionary\n",
+    "# made up of the facet as the key and value what to filter for.\n",
+    "# Just like others, it can be queried with other arguments:\n",
+    "result = Client.search(\n",
+    "    q=\"AerChem*\",\n",
+    "    filter={\n",
+    "     \"eq\": [\n",
+    "         {\"property\": \"institution_id\"},\n",
+    "         \"CNRM-CERFACS\"\n",
+    "     ]\n",
+    "  }\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Hello,

Would you like a binder interactive notebook to show examples interactively? The notebook I've used is a copy of the CEDA branch. Currently, our endpoint isn't public yet (waiting on certification), you can keep it as it is or change it to your endpoint for the usage example, subsequently changing the `collection_id` and `item_id` in the examples.

The notebook is also dependant on the `STAC.items()` method, if you wish to accept PR #109, else I can remove it.

If you do wish to accept this PR, the binder badge will need to be updated to stac.py, currently, it is directed to the cedadev fork.
```rst
.. image:: https://mybinder.org/badge_logo.svg
        :target: https://mybinder.org/v2/gh/brazil-data-cube/stac.py/master?filepath=examples%2Fusage.ipynb
        :alt: Binder interactive notebook
```
Again, if you wish to accept this PR, I can change it myself if requested. For now, I have kept it as it is to our fork.

Thanks again, we're very interested in using stac.py as our python client for STAC.